### PR TITLE
Eliminate the 'State' classes

### DIFF
--- a/app/src/main/java/com/ICS499/ThrownException/DigitalFileCabinet/LoginState.java
+++ b/app/src/main/java/com/ICS499/ThrownException/DigitalFileCabinet/LoginState.java
@@ -22,6 +22,18 @@ public class LoginState implements DFCState {
     public DFCState createAccount() {return null;}
 
     @Override
+    public void makeQuery(){
+        /* decide what query to make */
+        sqlContext = new QueryContext();
+        sqlContext.setQueryBuilder(addQuery);
+        /*add user data into the database */
+        addQuery = new AddUserQueryBuilder(getApplicationContext(), this);
+        sqlContext.makeQuery();
+        /*Select a user data from database*/
+        selectQuery = new SelectUserQueryBuilder(getApplicationContext());
+    }
+
+    @Override
     public DFCState deleteAccount() {return null;}
 
     @Override


### PR DESCRIPTION
We are consolidating the states in order to make the program more readable and reduce complexity.